### PR TITLE
Feature/object ref document

### DIFF
--- a/toop-edm/src/main/java/eu/toop/edm/EDMRequest.java
+++ b/toop-edm/src/main/java/eu/toop/edm/EDMRequest.java
@@ -170,7 +170,7 @@ public class EDMRequest
       case DOCUMENT:
         ValueEnforcer.notEmpty (aDistributions, "Distribution");
         break;
-      case GETOBJECTBYID:
+      case OBJECTREF:
         ValueEnforcer.notEmpty(sDocumentID, "Document ID");
         break;
       default:
@@ -513,7 +513,7 @@ public class EDMRequest
   @Nonnull
   public static Builder builderGetDocumentByID()
   {
-    return builder ().queryDefinition (EQueryDefinitionType.GETOBJECTBYID);
+    return builder ().queryDefinition (EQueryDefinitionType.OBJECTREF);
   }
 
   /**
@@ -901,13 +901,13 @@ public class EDMRequest
           if (m_sDocumentID != null)
             throw new IllegalStateException ("A Query Definition of type 'Document' must NOT contain a Document ID");
           break;
-        case GETOBJECTBYID:
+        case OBJECTREF:
           if (m_aConcepts.isNotEmpty ())
-            throw new IllegalStateException ("A Query Definition of type 'DocumentRef' must NOT contain a Concept");
+            throw new IllegalStateException ("A Query Definition of type 'GetObjectByID' must NOT contain a Concept");
           if (m_aDistributions.isNotEmpty ())
-            throw new IllegalStateException ("A Query Definition of type 'DocumentRef' must NOT contain a Distribution");
+            throw new IllegalStateException ("A Query Definition of type 'GetObjectByID' must NOT contain a Distribution");
           if (m_sDocumentID == null)
-            throw new IllegalStateException ("A Query Definition of type 'DocumentRef' must contain a Document ID");
+            throw new IllegalStateException ("A Query Definition of type 'GetObjectByID' must contain a Document ID");
           break;
         default:
           throw new IllegalStateException ("Unhandled query definition " + m_eQueryDefinition);
@@ -997,7 +997,7 @@ public class EDMRequest
         {
           final String sValue = ((StringValueType) aSlotValue).getValue ();
           aBuilder.documentID (sValue);
-          aBuilder.queryDefinition (EQueryDefinitionType.GETOBJECTBYID);
+          aBuilder.queryDefinition (EQueryDefinitionType.OBJECTREF);
         }
         break;
       case SlotDataConsumer.NAME:

--- a/toop-edm/src/main/java/eu/toop/edm/EDMRequest.java
+++ b/toop-edm/src/main/java/eu/toop/edm/EDMRequest.java
@@ -475,7 +475,7 @@ public class EDMRequest
                                        .append ("DataConsumer", m_aDataConsumer)
                                        .append ("ConsentToken", m_sConsentToken)
                                        .append ("DatasetIdentifier", m_sDatasetIdentifier)
-                                       .append ("Document ID", m_sDocumentID)
+                                       .append ("DocumentID", m_sDocumentID)
                                        .append ("DataSubjectLegalPerson", m_aDataSubjectLegalPerson)
                                        .append ("DataSubjectNaturalPerson", m_aDataSubjectNaturalPerson)
                                        .append ("AuthorizedRepresentative", m_aAuthorizedRepresentative)
@@ -489,7 +489,7 @@ public class EDMRequest
   {
     // Use the default specification identifier
     return new Builder ().specificationIdentifier (CToopEDM.SPECIFICATION_IDENTIFIER_TOOP_EDM_V20)
-            .responseOption(EResponseOptionType.LEAFCLASSWRI);
+            .responseOption(EResponseOptionType.CONTAINED);
   }
 
   @Nonnull
@@ -507,7 +507,7 @@ public class EDMRequest
   @Nonnull
   public static Builder builderDocumentRef ()
   {
-    return builder ().queryDefinition (EQueryDefinitionType.DOCUMENT).responseOption(EResponseOptionType.OBJECTREF);
+    return builder ().queryDefinition (EQueryDefinitionType.DOCUMENT).responseOption(EResponseOptionType.REFERENCED);
   }
 
   @Nonnull

--- a/toop-edm/src/main/java/eu/toop/edm/EDMResponse.java
+++ b/toop-edm/src/main/java/eu/toop/edm/EDMResponse.java
@@ -135,9 +135,6 @@ public class EDMResponse
         ValueEnforcer.notEmpty (aConcepts, "Concept");
         break;
       case DOCUMENT:
-        ValueEnforcer.notNull (aDataset, "Dataset");
-        ValueEnforcer.notNull (aRepositoryItemRef, "RepositoryItemRef");
-        break;
       case OBJECTREF:
         ValueEnforcer.notNull (aDataset, "Dataset");
         break;
@@ -593,8 +590,6 @@ public class EDMResponse
             throw new IllegalStateException ("A Query Definition of type 'Document' must NOT contain a Concept");
           if (m_aDataset == null)
             throw new IllegalStateException ("A Query Definition of type 'Document' must contain a Dataset");
-          if (m_aRepositoryItemRef == null)
-            throw new IllegalStateException ("A Query Definition of type 'Document' must contain a RepositoryItemRef");
           break;
         case OBJECTREF:
           if (m_aConcepts.isNotEmpty ())
@@ -602,7 +597,7 @@ public class EDMResponse
           if (m_aDataset == null)
             throw new IllegalStateException ("A Query Definition of type 'ObjectRef' must contain a Dataset");
           if (m_aRepositoryItemRef != null)
-            throw new IllegalStateException ("A Query Definition of type 'ObjectRef' must contain a RepositoryItemRef");
+            throw new IllegalStateException ("A Query Definition of type 'ObjectRef' must NOT contain a RepositoryItemRef");
           break;
         default:
           throw new IllegalStateException ("Unhandled query definition " + m_eQueryDefinition);

--- a/toop-edm/src/main/java/eu/toop/edm/EDMResponse.java
+++ b/toop-edm/src/main/java/eu/toop/edm/EDMResponse.java
@@ -25,6 +25,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.xml.datatype.XMLGregorianCalendar;
 
+import eu.toop.regrep.rim.*;
 import org.w3c.dom.Node;
 
 import com.helger.commons.ValueEnforcer;
@@ -71,14 +72,6 @@ import eu.toop.regrep.RegRep4Reader;
 import eu.toop.regrep.RegRep4Writer;
 import eu.toop.regrep.RegRepHelper;
 import eu.toop.regrep.query.QueryResponse;
-import eu.toop.regrep.rim.AnyValueType;
-import eu.toop.regrep.rim.CollectionValueType;
-import eu.toop.regrep.rim.DateTimeValueType;
-import eu.toop.regrep.rim.RegistryObjectListType;
-import eu.toop.regrep.rim.RegistryObjectType;
-import eu.toop.regrep.rim.SlotType;
-import eu.toop.regrep.rim.StringValueType;
-import eu.toop.regrep.rim.ValueType;
 
 /**
  * This class contains the data model for a single TOOP EDM Request. It requires
@@ -145,6 +138,8 @@ public class EDMResponse
       case DOCUMENT:
         ValueEnforcer.notNull (aDataset, "Dataset");
         break;
+      case GETOBJECTBYID:
+// break;
       default:
         throw new IllegalArgumentException ("Unsupported query definition: " + eQueryDefinition);
     }
@@ -244,6 +239,14 @@ public class EDMResponse
     {
       final RegistryObjectListType aROList = new RegistryObjectListType ();
       final RegistryObjectType aRO = new RegistryObjectType ();
+      final SimpleLinkType aSL = new SimpleLinkType();
+
+      // Setter currently not available
+//      aRO.setRepositoryItemRef(aSL);
+
+      aSL.setTitle("TEST");
+      aSL.setHref("cid:attachment123@example.toop.eu");
+
       aRO.setId (UUID.randomUUID ().toString ());
 
       // All slots inside of RegistryObject

--- a/toop-edm/src/main/java/eu/toop/edm/model/EQueryDefinitionType.java
+++ b/toop-edm/src/main/java/eu/toop/edm/model/EQueryDefinitionType.java
@@ -31,7 +31,7 @@ public enum EQueryDefinitionType implements IHasID <String>
 {
   CONCEPT ("ConceptQuery"),
   DOCUMENT ("DocumentQuery"),
-  GETOBJECTBYID("urn:oasis:names:tc:ebxml-regrep:query:GetObjectById");
+  OBJECTREF("urn:oasis:names:tc:ebxml-regrep:query:GetObjectById");
 
   private String m_sID;
 

--- a/toop-edm/src/main/java/eu/toop/edm/model/EQueryDefinitionType.java
+++ b/toop-edm/src/main/java/eu/toop/edm/model/EQueryDefinitionType.java
@@ -30,7 +30,8 @@ import com.helger.commons.lang.EnumHelper;
 public enum EQueryDefinitionType implements IHasID <String>
 {
   CONCEPT ("ConceptQuery"),
-  DOCUMENT ("DocumentQuery");
+  DOCUMENT ("DocumentQuery"),
+  GETOBJECTBYID("urn:oasis:names:tc:ebxml-regrep:query:GetObjectById");
 
   private String m_sID;
 

--- a/toop-edm/src/main/java/eu/toop/edm/model/EResponseOptionType.java
+++ b/toop-edm/src/main/java/eu/toop/edm/model/EResponseOptionType.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2018-2020 toop.eu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package eu.toop.edm.model;
 
 import com.helger.commons.annotation.Nonempty;
@@ -9,8 +24,8 @@ import javax.annotation.Nullable;
 
 public enum EResponseOptionType implements IHasID<String>
 {
-    LEAFCLASSWRI("LeafClassWithRepositoryItem"),
-    OBJECTREF("ObjectRef");
+    CONTAINED("LeafClassWithRepositoryItem"),
+    REFERENCED("ObjectRef");
 
     private final String m_sID;
 

--- a/toop-edm/src/main/java/eu/toop/edm/model/EResponseOptionType.java
+++ b/toop-edm/src/main/java/eu/toop/edm/model/EResponseOptionType.java
@@ -1,0 +1,34 @@
+package eu.toop.edm.model;
+
+import com.helger.commons.annotation.Nonempty;
+import com.helger.commons.id.IHasID;
+import com.helger.commons.lang.EnumHelper;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public enum EResponseOptionType implements IHasID<String>
+{
+    LEAFCLASSWRI("LeafClassWithRepositoryItem"),
+    OBJECTREF("ObjectRef");
+
+    private final String m_sID;
+
+    EResponseOptionType (@Nonnull @Nonempty final String sID)
+    {
+        m_sID = sID;
+    }
+
+    @Nonnull
+    @Nonempty
+    public String getID ()
+    {
+        return m_sID;
+    }
+
+    @Nullable
+    public static EResponseOptionType getFromIDOrNull (@Nullable final String sID)
+    {
+        return EnumHelper.getFromIDOrNull (EResponseOptionType.class, sID);
+    }
+}

--- a/toop-edm/src/main/java/eu/toop/edm/model/RepositoryItemRefPojo.java
+++ b/toop-edm/src/main/java/eu/toop/edm/model/RepositoryItemRefPojo.java
@@ -8,6 +8,7 @@ import eu.toop.regrep.rim.SimpleLinkType;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
@@ -35,14 +36,11 @@ public class RepositoryItemRefPojo
     }
 
     @Nonnull
-    public SimpleLinkType getAsExternalLink (){
+    public SimpleLinkType getAsSimpleLink (){
         final SimpleLinkType ret = new SimpleLinkType ();
         ret.setTitle (m_sTitle);
-        try {
-            ret.setHref (URLEncoder.encode(m_sLink, StandardCharsets.UTF_8.toString()));
-        } catch (UnsupportedEncodingException e) {
-            e.printStackTrace();
-        }
+        ret.setHref(m_sLink);
+
         return ret;
     }
 
@@ -79,8 +77,9 @@ public class RepositoryItemRefPojo
     public static RepositoryItemRefPojo.Builder builder (@Nullable final SimpleLinkType a)
     {
         final RepositoryItemRefPojo.Builder ret = new RepositoryItemRefPojo.Builder();
-        if (a != null)
+        if (a != null) {
             return ret.link(a.getHref()).title(a.getTitle());
+        }
         return ret;
     }
 

--- a/toop-edm/src/main/java/eu/toop/edm/model/RepositoryItemRefPojo.java
+++ b/toop-edm/src/main/java/eu/toop/edm/model/RepositoryItemRefPojo.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2018-2020 toop.eu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package eu.toop.edm.model;
 
 import com.helger.commons.equals.EqualsHelper;
@@ -7,10 +22,6 @@ import eu.toop.regrep.rim.SimpleLinkType;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 
 public class RepositoryItemRefPojo
 {
@@ -19,8 +30,8 @@ public class RepositoryItemRefPojo
 
     public RepositoryItemRefPojo (@Nullable final String sTitle, @Nullable final String sLink)
     {
-        m_sLink = sLink;
         m_sTitle = sTitle;
+        m_sLink = sLink;
     }
 
     @Nullable
@@ -38,9 +49,10 @@ public class RepositoryItemRefPojo
     @Nonnull
     public SimpleLinkType getAsSimpleLink (){
         final SimpleLinkType ret = new SimpleLinkType ();
-        ret.setTitle (m_sTitle);
-        ret.setHref(m_sLink);
-
+        if(m_sTitle != null)
+            ret.setTitle (m_sTitle);
+        if(m_sLink != null)
+            ret.setHref(m_sLink);
         return ret;
     }
 
@@ -52,7 +64,7 @@ public class RepositoryItemRefPojo
         if (o == null || !getClass ().equals (o.getClass ()))
             return false;
         final RepositoryItemRefPojo rhs = (RepositoryItemRefPojo) o;
-        return EqualsHelper.equals (m_sLink, rhs.m_sLink) && EqualsHelper.equals (m_sTitle, rhs.m_sTitle);
+        return EqualsHelper.equals (m_sTitle, rhs.m_sTitle) && EqualsHelper.equals (m_sLink, rhs.m_sLink);
     }
 
     @Override
@@ -78,7 +90,11 @@ public class RepositoryItemRefPojo
     {
         final RepositoryItemRefPojo.Builder ret = new RepositoryItemRefPojo.Builder();
         if (a != null) {
-            return ret.link(a.getHref()).title(a.getTitle());
+            if(a.getTitle() != null)
+                ret.title(a.getTitle());
+            if(a.getHref() != null)
+                ret.link(a.getHref());
+            return ret;
         }
         return ret;
     }
@@ -91,14 +107,15 @@ public class RepositoryItemRefPojo
         public Builder ()
         {}
 
-        public RepositoryItemRefPojo.Builder title (@Nonnull final String sTitle)
+        @Nonnull
+        public RepositoryItemRefPojo.Builder title (@Nullable final String sTitle)
         {
             m_sTitle = sTitle;
             return this;
         }
 
         @Nonnull
-        public RepositoryItemRefPojo.Builder link (@Nonnull final String sLink)
+        public RepositoryItemRefPojo.Builder link (@Nullable final String sLink)
         {
             m_sLink = sLink;
             return this;

--- a/toop-edm/src/main/java/eu/toop/edm/model/RepositoryItemRefPojo.java
+++ b/toop-edm/src/main/java/eu/toop/edm/model/RepositoryItemRefPojo.java
@@ -1,0 +1,114 @@
+package eu.toop.edm.model;
+
+import com.helger.commons.equals.EqualsHelper;
+import com.helger.commons.hashcode.HashCodeGenerator;
+import com.helger.commons.string.ToStringGenerator;
+import eu.toop.regrep.rim.SimpleLinkType;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+public class RepositoryItemRefPojo
+{
+    private final String m_sTitle;
+    private final String m_sLink;
+
+    public RepositoryItemRefPojo (@Nullable final String sTitle, @Nullable final String sLink)
+    {
+        m_sLink = sLink;
+        m_sTitle = sTitle;
+    }
+
+    @Nullable
+    public final String getTitle ()
+    {
+        return m_sTitle;
+    }
+
+    @Nullable
+    public final String getLink ()
+    {
+        return m_sLink;
+    }
+
+    @Nonnull
+    public SimpleLinkType getAsExternalLink (){
+        final SimpleLinkType ret = new SimpleLinkType ();
+        ret.setTitle (m_sTitle);
+        try {
+            ret.setHref (URLEncoder.encode(m_sLink, StandardCharsets.UTF_8.toString()));
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+        return ret;
+    }
+
+    @Override
+    public boolean equals (final Object o)
+    {
+        if (o == this)
+            return true;
+        if (o == null || !getClass ().equals (o.getClass ()))
+            return false;
+        final RepositoryItemRefPojo rhs = (RepositoryItemRefPojo) o;
+        return EqualsHelper.equals (m_sLink, rhs.m_sLink) && EqualsHelper.equals (m_sTitle, rhs.m_sTitle);
+    }
+
+    @Override
+    public int hashCode ()
+    {
+        return new HashCodeGenerator(this).append (m_sTitle).append (m_sLink).getHashCode ();
+    }
+
+    @Override
+    public String toString ()
+    {
+        return new ToStringGenerator(this).append ("Title", m_sTitle).append ("Link", m_sLink).getToString ();
+    }
+
+    @Nonnull
+    public static RepositoryItemRefPojo.Builder builder ()
+    {
+        return new RepositoryItemRefPojo.Builder();
+    }
+
+    @Nonnull
+    public static RepositoryItemRefPojo.Builder builder (@Nullable final SimpleLinkType a)
+    {
+        final RepositoryItemRefPojo.Builder ret = new RepositoryItemRefPojo.Builder();
+        if (a != null)
+            return ret.link(a.getHref()).title(a.getTitle());
+        return ret;
+    }
+
+    public static class Builder
+    {
+        private String m_sTitle;
+        private String m_sLink;
+
+        public Builder ()
+        {}
+
+        public RepositoryItemRefPojo.Builder title (@Nonnull final String sTitle)
+        {
+            m_sTitle = sTitle;
+            return this;
+        }
+
+        @Nonnull
+        public RepositoryItemRefPojo.Builder link (@Nonnull final String sLink)
+        {
+            m_sLink = sLink;
+            return this;
+        }
+
+        @Nonnull
+        public RepositoryItemRefPojo build ()
+        {
+            return new RepositoryItemRefPojo (m_sTitle, m_sLink);
+        }
+    }
+}

--- a/toop-edm/src/main/java/eu/toop/edm/slot/SlotId.java
+++ b/toop-edm/src/main/java/eu/toop/edm/slot/SlotId.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2018-2020 toop.eu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package eu.toop.edm.slot;
 
 import com.helger.commons.ValueEnforcer;

--- a/toop-edm/src/main/java/eu/toop/edm/slot/SlotId.java
+++ b/toop-edm/src/main/java/eu/toop/edm/slot/SlotId.java
@@ -1,0 +1,34 @@
+package eu.toop.edm.slot;
+
+import com.helger.commons.ValueEnforcer;
+import com.helger.commons.annotation.Nonempty;
+import eu.toop.regrep.SlotBuilder;
+import eu.toop.regrep.rim.SlotType;
+
+import javax.annotation.Nonnull;
+
+public class SlotId implements ISlotProvider
+{
+    public static final String NAME = "id";
+
+    private final String m_sValue;
+
+    public SlotId (@Nonnull final String sValue)
+    {
+        ValueEnforcer.notNull (sValue, "Value");
+        m_sValue = sValue;
+    }
+
+    @Nonnull
+    @Nonempty
+    public String getName ()
+    {
+        return NAME;
+    }
+
+    @Nonnull
+    public SlotType createSlot ()
+    {
+        return new SlotBuilder().setName (NAME).setValue (m_sValue).build ();
+    }
+}

--- a/toop-edm/src/test/java/eu/toop/edm/EDMRequestTest.java
+++ b/toop-edm/src/test/java/eu/toop/edm/EDMRequestTest.java
@@ -26,6 +26,9 @@ import java.util.Locale;
 
 import javax.annotation.Nonnull;
 
+import eu.toop.edm.model.*;
+import eu.toop.edm.xml.cagv.CCAGV;
+import eu.toop.regrep.RegRep4Reader;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
@@ -37,15 +40,6 @@ import com.helger.commons.mock.CommonsTestHelper;
 import com.helger.schematron.svrl.AbstractSVRLMessage;
 
 import eu.toop.edm.jaxb.cccev.CCCEVRequirementType;
-import eu.toop.edm.model.AddressPojo;
-import eu.toop.edm.model.AgentPojo;
-import eu.toop.edm.model.BusinessPojo;
-import eu.toop.edm.model.ConceptPojo;
-import eu.toop.edm.model.DistributionPojo;
-import eu.toop.edm.model.EDistributionFormat;
-import eu.toop.edm.model.EGenderCode;
-import eu.toop.edm.model.EQueryDefinitionType;
-import eu.toop.edm.model.PersonPojo;
 import eu.toop.edm.pilot.gbm.EToopConcept;
 import eu.toop.edm.schematron.SchematronEDM2Validator;
 
@@ -60,12 +54,14 @@ public final class EDMRequestTest
   {
     assertNotNull (aReq);
 
+    System.out.println(aReq.getWriter().getAsString());
+
     // Write
     final byte [] aBytes = aReq.getWriter ().getAsBytes ();
     assertNotNull (aBytes);
 
     // Re-read
-    final EDMRequest aReq2 = EDMRequest.getReader ().read (aBytes);
+    final EDMRequest aReq2 = EDMRequest.create(RegRep4Reader.queryRequest(CCAGV.XSDS).read(aBytes));
 
     // Compare with original
     assertEquals (aReq, aReq2);
@@ -144,6 +140,13 @@ public final class EDMRequestTest
   }
 
   @Nonnull
+  private static EDMRequest.Builder _reqDocumentByID()
+  {
+    return _req ().queryDefinition (EQueryDefinitionType.GETOBJECTBYID)
+            .documentID("a document id");
+  }
+
+  @Nonnull
   private static PersonPojo.Builder _np ()
   {
     return PersonPojo.builder ()
@@ -209,6 +212,28 @@ public final class EDMRequestTest
     _testWriteAndRead (aRequest);
   }
 
+  @Test
+  public void createEDMDocumentGetByIDRequestLP ()
+  {
+    final EDMRequest aRequest = _reqDocumentByID().dataSubject (_lp ()).build ();
+    _testWriteAndRead (aRequest);
+  }
+
+  @Test
+  public void createEDMDocumentGetByIDRequestNP ()
+  {
+    final EDMRequest aRequest = _reqDocumentByID().dataSubject (_np ()).build ();
+    _testWriteAndRead (aRequest);
+  }
+
+  @Test
+  public void createEDMDocumentRefRequestNP ()
+  {
+    final EDMRequest aRequest = _reqDocument ().dataSubject (_np ())
+            .responseOption(EResponseOptionType.OBJECTREF).build ();
+    _testWriteAndRead (aRequest);
+  }
+
   public void createInvalidEDMRequest ()
   {
     try
@@ -242,6 +267,8 @@ public final class EDMRequestTest
 
     aRequest = EDMRequest.getReader ().read (new ClassPathResource ("Document Request_NP.xml"));
     _testWriteAndRead (aRequest);
+
+
   }
 
   @Test

--- a/toop-edm/src/test/java/eu/toop/edm/EDMRequestTest.java
+++ b/toop-edm/src/test/java/eu/toop/edm/EDMRequestTest.java
@@ -55,8 +55,6 @@ public final class EDMRequestTest
   {
     assertNotNull (aReq);
 
-    System.out.println(aReq.getWriter().getAsString());
-
     // Write
     final byte [] aBytes = aReq.getWriter ().getAsBytes ();
     assertNotNull (aBytes);

--- a/toop-edm/src/test/java/eu/toop/edm/EDMRequestTest.java
+++ b/toop-edm/src/test/java/eu/toop/edm/EDMRequestTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.fail;
 
 import java.time.Month;
 import java.util.Locale;
+import java.util.UUID;
 
 import javax.annotation.Nonnull;
 
@@ -61,7 +62,7 @@ public final class EDMRequestTest
     assertNotNull (aBytes);
 
     // Re-read
-    final EDMRequest aReq2 = EDMRequest.create(RegRep4Reader.queryRequest(CCAGV.XSDS).read(aBytes));
+    final EDMRequest aReq2 = EDMRequest.getReader().read(aBytes);
 
     // Compare with original
     assertEquals (aReq, aReq2);
@@ -142,8 +143,8 @@ public final class EDMRequestTest
   @Nonnull
   private static EDMRequest.Builder _reqDocumentByID()
   {
-    return _req ().queryDefinition (EQueryDefinitionType.GETOBJECTBYID)
-            .documentID("a document id");
+    return _req ().queryDefinition (EQueryDefinitionType.OBJECTREF)
+            .documentID(UUID.randomUUID().toString());
   }
 
   @Nonnull

--- a/toop-edm/src/test/java/eu/toop/edm/EDMRequestTest.java
+++ b/toop-edm/src/test/java/eu/toop/edm/EDMRequestTest.java
@@ -28,8 +28,6 @@ import java.util.UUID;
 import javax.annotation.Nonnull;
 
 import eu.toop.edm.model.*;
-import eu.toop.edm.xml.cagv.CCAGV;
-import eu.toop.regrep.RegRep4Reader;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
@@ -229,7 +227,7 @@ public final class EDMRequestTest
   public void createEDMDocumentRefRequestNP ()
   {
     final EDMRequest aRequest = _reqDocument ().dataSubject (_np ())
-            .responseOption(EResponseOptionType.OBJECTREF).build ();
+            .responseOption(EResponseOptionType.REFERENCED).build ();
     _testWriteAndRead (aRequest);
   }
 
@@ -266,8 +264,6 @@ public final class EDMRequestTest
 
     aRequest = EDMRequest.getReader ().read (new ClassPathResource ("Document Request_NP.xml"));
     _testWriteAndRead (aRequest);
-
-
   }
 
   @Test

--- a/toop-edm/src/test/java/eu/toop/edm/EDMResponseTest.java
+++ b/toop-edm/src/test/java/eu/toop/edm/EDMResponseTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2018-2020 toop.eu
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,194 +15,171 @@
  */
 package eu.toop.edm;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.time.Month;
-import java.util.UUID;
-
-import javax.annotation.Nonnull;
-
-import org.junit.Test;
-import org.w3c.dom.Document;
-
 import com.helger.commons.collection.impl.ICommonsList;
 import com.helger.commons.datetime.PDTFactory;
 import com.helger.commons.io.resource.ClassPathResource;
 import com.helger.commons.mock.CommonsTestHelper;
 import com.helger.schematron.svrl.AbstractSVRLMessage;
-
-import eu.toop.edm.model.AddressPojo;
-import eu.toop.edm.model.AgentPojo;
-import eu.toop.edm.model.ConceptPojo;
-import eu.toop.edm.model.DatasetPojo;
-import eu.toop.edm.model.DocumentReferencePojo;
-import eu.toop.edm.model.EQueryDefinitionType;
-import eu.toop.edm.model.QualifiedRelationPojo;
+import eu.toop.edm.model.*;
 import eu.toop.edm.pilot.gbm.EToopConcept;
 import eu.toop.edm.schematron.SchematronEDM2Validator;
 import eu.toop.regrep.ERegRepResponseStatus;
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+import javax.annotation.Nonnull;
+import javax.swing.text.DateFormatter;
+import java.time.Month;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
 
 /**
  * Test class for class {@link EDMResponse}.
  *
  * @author Philip Helger
  */
-public final class EDMResponseTest
-{
-  private static void _testWriteAndRead (@Nonnull final EDMResponse aResp)
-  {
-    assertNotNull (aResp);
+public final class EDMResponseTest {
+    private static void _testWriteAndRead(@Nonnull final EDMResponse aResp) {
+        assertNotNull(aResp);
 
-    // Write
-    final byte [] aBytes = aResp.getWriter ().getAsBytes ();
-    assertNotNull (aBytes);
+        System.out.println(aResp.getWriter().getAsString());
+        // Write
+        final byte[] aBytes = aResp.getWriter().getAsBytes();
+        assertNotNull(aBytes);
 
-    // Re-read
-    final EDMResponse aResp2 = EDMResponse.getReader ().read (aBytes);
+        // Re-read
+        final EDMResponse aResp2 = EDMResponse.getReader().read(aBytes);
 
-    // Compare with original
-    assertEquals (aResp, aResp2);
-    CommonsTestHelper.testDefaultImplementationWithEqualContentObject (aResp, aResp2);
+        // Compare with original
+        assertEquals(aResp, aResp2);
+        CommonsTestHelper.testDefaultImplementationWithEqualContentObject(aResp, aResp2);
 
-    {
-      // Schematron validation
-      final Document aDoc = aResp.getWriter ().getAsDocument ();
-      assertNotNull (aDoc);
-      final ICommonsList <AbstractSVRLMessage> aMsgs = new SchematronEDM2Validator ().validateDocument (aDoc);
-      assertTrue (aMsgs.toString (), aMsgs.isEmpty ());
+        {
+            // Schematron validation
+            final Document aDoc = aResp.getWriter().getAsDocument();
+            assertNotNull(aDoc);
+            final ICommonsList<AbstractSVRLMessage> aMsgs = new SchematronEDM2Validator().validateDocument(aDoc);
+            assertTrue(aMsgs.toString(), aMsgs.isEmpty());
+        }
     }
-  }
 
-  @Nonnull
-  private static EDMResponse.Builder _resp ()
-  {
-    return EDMResponse.builder ()
-                      .requestID (UUID.randomUUID ())
-                      .issueDateTimeNow ()
-                      .dataProvider (AgentPojo.builder ()
-                                              .address (AddressPojo.builder ()
-                                                                   .town ("MyTown")
-                                                                   .streetName ("MyStreet")
-                                                                   .buildingNumber ("22")
-                                                                   .countryCode ("GR")
-                                                                   .fullAddress ("MyStreet 22, 11134, MyTown, GR")
-                                                                   .postalCode ("11134")
-                                                                   .build ())
-                                              .name ("DP NAME")
-                                              .id ("1234")
-                                              .idSchemeID ("VAT")
-                                              .build ())
-                      .responseStatus (ERegRepResponseStatus.SUCCESS)
-                      .specificationIdentifier ("Niar");
-  }
-
-  @Nonnull
-  private static EDMResponse.Builder _respConcept ()
-  {
-    return _resp ().queryDefinition (EQueryDefinitionType.CONCEPT)
-                   .concept (ConceptPojo.builder ()
-                                        .id ("ConceptID-1")
-                                        .name (EToopConcept.REGISTERED_ORGANIZATION)
-                                        .addChild (ConceptPojo.builder ()
-                                                              .randomID ()
-                                                              .name (EToopConcept.COMPANY_NAME)
-                                                              .valueText ("Helger Enterprises"))
-                                        .addChild (ConceptPojo.builder ()
-                                                              .randomID ()
-                                                              .name (EToopConcept.FAX_NUMBER)
-                                                              .valueText ("342342424"))
-                                        .addChild (ConceptPojo.builder ()
-                                                              .randomID ()
-                                                              .name (EToopConcept.FOUNDATION_DATE)
-                                                              .valueDate (PDTFactory.createLocalDate (1960,
-                                                                                                      Month.AUGUST,
-                                                                                                      12))));
-  }
-
-  @Nonnull
-  private static DatasetPojo.Builder _dataset ()
-  {
-    return DatasetPojo.builder ()
-                      .description ("bla desc")
-                      .title ("bla title")
-                      .distribution (DocumentReferencePojo.builder ()
-                                                          .documentURI ("URI")
-                                                          .documentDescription ("DocumentDescription")
-                                                          .documentType ("docType")
-                                                          .localeCode ("GR"))
-                      .creator (AgentPojo.builder ()
-                                         .name ("Agent name")
-                                         .address (AddressPojo.builder ().town ("Kewlkidshome")))
-                      .ids ("RE238918378", "DOC-555")
-                      .issuedNow ()
-                      .language ("en")
-                      .lastModifiedNow ()
-                      .validFrom (PDTFactory.getCurrentLocalDate ().minusMonths (1))
-                      .validTo (PDTFactory.getCurrentLocalDate ().plusYears (1))
-                      .qualifiedRelation (QualifiedRelationPojo.builder ()
-                                                               .description ("LegalResourceDesc")
-                                                               .title ("Name")
-                                                               .id ("RE238918378"));
-  }
-
-  @Nonnull
-  private static EDMResponse.Builder _respDocument ()
-  {
-    return _resp ().queryDefinition (EQueryDefinitionType.DOCUMENT).dataset (_dataset ());
-  }
-
-  @Test
-  public void createConceptResponse ()
-  {
-    final EDMResponse aResp = _respConcept ().build ();
-    _testWriteAndRead (aResp);
-  }
-
-  @Test
-  public void createDocumentResponse ()
-  {
-    final EDMResponse aResp = _respDocument ().build ();
-    _testWriteAndRead (aResp);
-  }
-
-  @Test
-  public void createDocumentResponseWithConceptType ()
-  {
-    try
-    {
-      // This attempts to create an EDMResponse with a dataset element but with
-      // ConceptQuery set as the QueryDefinition
-      // which is not permitted and fails
-      _respConcept ().dataset (_dataset ()).build ();
-      fail ();
+    @Nonnull
+    private static EDMResponse.Builder _resp() {
+        return EDMResponse.builder()
+                .requestID(UUID.randomUUID())
+                .issueDateTimeNow()
+                .dataProvider(AgentPojo.builder()
+                        .address(AddressPojo.builder()
+                                .town("MyTown")
+                                .streetName("MyStreet")
+                                .buildingNumber("22")
+                                .countryCode("GR")
+                                .fullAddress("MyStreet 22, 11134, MyTown, GR")
+                                .postalCode("11134")
+                                .build())
+                        .name("DP NAME")
+                        .id("1234")
+                        .idSchemeID("VAT")
+                        .build())
+                .responseStatus(ERegRepResponseStatus.SUCCESS)
+                .specificationIdentifier("Niar");
     }
-    catch (final IllegalStateException ex)
-    {
-      // Expected
+
+    @Nonnull
+    private static EDMResponse.Builder _respConcept() {
+        return _resp().queryDefinition(EQueryDefinitionType.CONCEPT)
+                .concept(ConceptPojo.builder()
+                        .id("ConceptID-1")
+                        .name(EToopConcept.REGISTERED_ORGANIZATION)
+                        .addChild(ConceptPojo.builder()
+                                .randomID()
+                                .name(EToopConcept.COMPANY_NAME)
+                                .valueText("Helger Enterprises"))
+                        .addChild(ConceptPojo.builder()
+                                .randomID()
+                                .name(EToopConcept.FAX_NUMBER)
+                                .valueText("342342424"))
+                        .addChild(ConceptPojo.builder()
+                                .randomID()
+                                .name(EToopConcept.FOUNDATION_DATE)
+                                .valueDate(PDTFactory.createLocalDate(1960,
+                                        Month.AUGUST,
+                                        12))));
     }
-  }
 
-  @Test
-  public void testReadAndWriteExampleFiles ()
-  {
-    EDMResponse aResponse = EDMResponse.getReader ().read (new ClassPathResource ("Concept Response.xml"));
-    _testWriteAndRead (aResponse);
+    @Nonnull
+    private static DatasetPojo.Builder _dataset() {
+        return DatasetPojo.builder()
+                .description("bla desc")
+                .title("bla title")
+                .distribution(DocumentReferencePojo.builder()
+                        .documentURI("URI")
+                        .documentDescription("DocumentDescription")
+                        .documentType("docType")
+                        .localeCode("GR"))
+                .creator(AgentPojo.builder()
+                        .name("Agent name")
+                        .address(AddressPojo.builder().town("Kewlkidshome")))
+                .ids("RE238918378", "DOC-555")
+                .issuedNow()
+                .language("en")
+                .lastModifiedNow()
+                .validFrom(PDTFactory.getCurrentLocalDate().minusMonths(1))
+                .validTo(PDTFactory.getCurrentLocalDate().plusYears(1))
+                .qualifiedRelation(QualifiedRelationPojo.builder()
+                        .description("LegalResourceDesc")
+                        .title("Name")
+                        .id("RE238918378"));
+    }
 
-    aResponse = EDMResponse.getReader ().read (new ClassPathResource ("Document Response.xml"));
-    _testWriteAndRead (aResponse);
-  }
+    @Nonnull
+    private static EDMResponse.Builder _respDocument() {
+        return _resp().queryDefinition(EQueryDefinitionType.DOCUMENT).dataset(_dataset());
+    }
 
-  @Test
-  public void testBadCases ()
-  {
-    EDMResponse aResponse = EDMResponse.getReader ().read (new ClassPathResource ("Bogus.xml"));
-    assertNull (aResponse);
+    @Test
+    public void createConceptResponse() {
+        final EDMResponse aResp1 = _respConcept().build();
+        EDMResponse aResp = EDMResponse.getReader().read(ClassPathResource.getInputStream("Concept Response.xml"));
+        _testWriteAndRead(aResp);
+    }
 
-    aResponse = EDMResponse.getReader ().read (new ClassPathResource ("Concept Request_LP.xml"));
-    assertNull (aResponse);
-  }
+    @Test
+    public void createDocumentResponse() {
+        final EDMResponse aResp = _respDocument().build();
+        _testWriteAndRead(aResp);
+    }
+
+    @Test
+    public void createDocumentResponseWithConceptType() {
+        try {
+            // This attempts to create an EDMResponse with a dataset element but with
+            // ConceptQuery set as the QueryDefinition
+            // which is not permitted and fails
+            _respConcept().dataset(_dataset()).build();
+            fail();
+        } catch (final IllegalStateException ex) {
+            // Expected
+        }
+    }
+
+    @Test
+    public void testReadAndWriteExampleFiles() {
+        EDMResponse aResponse = EDMResponse.getReader().read(new ClassPathResource("Concept Response.xml"));
+        _testWriteAndRead(aResponse);
+
+        aResponse = EDMResponse.getReader().read(new ClassPathResource("Document Response.xml"));
+        _testWriteAndRead(aResponse);
+    }
+
+    @Test
+    public void testBadCases() {
+        EDMResponse aResponse = EDMResponse.getReader().read(new ClassPathResource("Bogus.xml"));
+        assertNull(aResponse);
+
+        aResponse = EDMResponse.getReader().read(new ClassPathResource("Concept Request_LP.xml"));
+        assertNull(aResponse);
+    }
 }

--- a/toop-edm/src/test/java/eu/toop/edm/EDMResponseTest.java
+++ b/toop-edm/src/test/java/eu/toop/edm/EDMResponseTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2018-2020 toop.eu
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -150,8 +150,7 @@ public final class EDMResponseTest {
     @Test
     public void createConceptResponse() {
         final EDMResponse aResp1 = _respConcept().build();
-        EDMResponse aResp = EDMResponse.create(RegRep4Reader.queryResponse(CCAGV.XSDS).read(ClassPathResource.getInputStream("Concept Response.xml")));
-//        EDMResponse aResp = EDMResponse.getReader().read(ClassPathResource.getInputStream("Concept Response.xml"));
+        EDMResponse aResp = EDMResponse.getReader().read(ClassPathResource.getInputStream("Concept Response.xml"));
         _testWriteAndRead(aResp);
     }
 
@@ -186,6 +185,9 @@ public final class EDMResponseTest {
         _testWriteAndRead(aResponse);
 
         aResponse = EDMResponse.getReader().read(new ClassPathResource("Document Response.xml"));
+        _testWriteAndRead(aResponse);
+
+        aResponse = EDMResponse.getReader().read(new ClassPathResource("Document Response_NoRepositoryItemRef.xml"));
         _testWriteAndRead(aResponse);
     }
 

--- a/toop-edm/src/test/java/eu/toop/edm/EDMResponseTest.java
+++ b/toop-edm/src/test/java/eu/toop/edm/EDMResponseTest.java
@@ -23,14 +23,14 @@ import com.helger.schematron.svrl.AbstractSVRLMessage;
 import eu.toop.edm.model.*;
 import eu.toop.edm.pilot.gbm.EToopConcept;
 import eu.toop.edm.schematron.SchematronEDM2Validator;
+import eu.toop.edm.xml.cagv.CCAGV;
 import eu.toop.regrep.ERegRepResponseStatus;
+import eu.toop.regrep.RegRep4Reader;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
 import javax.annotation.Nonnull;
-import javax.swing.text.DateFormatter;
 import java.time.Month;
-import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 
 import static org.junit.Assert.*;
@@ -136,13 +136,23 @@ public final class EDMResponseTest {
 
     @Nonnull
     private static EDMResponse.Builder _respDocument() {
-        return _resp().queryDefinition(EQueryDefinitionType.DOCUMENT).dataset(_dataset());
+        return _resp().queryDefinition(EQueryDefinitionType.DOCUMENT).dataset(_dataset())
+                .repositoryItemRef(
+                        RepositoryItemRefPojo.builder()
+                                .title("Evidence.pdf")
+                                .link("https://www.example.com/evidence.pdf"));
+    }
+
+    @Nonnull
+    private static EDMResponse.Builder _respDocumentRef() {
+        return _resp().queryDefinition(EQueryDefinitionType.OBJECTREF).dataset(_dataset());
     }
 
     @Test
     public void createConceptResponse() {
         final EDMResponse aResp1 = _respConcept().build();
-        EDMResponse aResp = EDMResponse.getReader().read(ClassPathResource.getInputStream("Concept Response.xml"));
+        EDMResponse aResp = EDMResponse.create(RegRep4Reader.queryResponse(CCAGV.XSDS).read(ClassPathResource.getInputStream("Concept Response.xml")));
+//        EDMResponse aResp = EDMResponse.getReader().read(ClassPathResource.getInputStream("Concept Response.xml"));
         _testWriteAndRead(aResp);
     }
 
@@ -153,6 +163,12 @@ public final class EDMResponseTest {
     }
 
     @Test
+    public void createDocumentRefResponse() {
+        final EDMResponse aResp = _respDocumentRef().build();
+        _testWriteAndRead(aResp);
+    }
+
+
     public void createDocumentResponseWithConceptType() {
         try {
             // This attempts to create an EDMResponse with a dataset element but with

--- a/toop-edm/src/test/java/eu/toop/edm/EDMResponseTest.java
+++ b/toop-edm/src/test/java/eu/toop/edm/EDMResponseTest.java
@@ -44,7 +44,6 @@ public final class EDMResponseTest {
     private static void _testWriteAndRead(@Nonnull final EDMResponse aResp) {
         assertNotNull(aResp);
 
-        System.out.println(aResp.getWriter().getAsString());
         // Write
         final byte[] aBytes = aResp.getWriter().getAsBytes();
         assertNotNull(aBytes);

--- a/toop-edm/src/test/resources/Document Response.xml
+++ b/toop-edm/src/test/resources/Document Response.xml
@@ -16,7 +16,7 @@
     limitations under the License.
 
 -->
-<query:QueryResponse xmlns:lcm="urn:oasis:names:tc:ebxml-regrep:xsd:lcm:4.0" xmlns:query="urn:oasis:names:tc:ebxml-regrep:xsd:query:4.0" xmlns:spi="urn:oasis:names:tc:ebxml-regrep:xsd:spi:4.0" xmlns:rs="urn:oasis:names:tc:ebxml-regrep:xsd:rs:4.0" xmlns:wsa="http://www.w3.org/2005/08/addressing" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:4.0" status="urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success" requestId="c4369c4d-740e-4b64-80f0-7b209a66d629">
+<query:QueryResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:lcm="urn:oasis:names:tc:ebxml-regrep:xsd:lcm:4.0" xmlns:query="urn:oasis:names:tc:ebxml-regrep:xsd:query:4.0" xmlns:spi="urn:oasis:names:tc:ebxml-regrep:xsd:spi:4.0" xmlns:rs="urn:oasis:names:tc:ebxml-regrep:xsd:rs:4.0" xmlns:wsa="http://www.w3.org/2005/08/addressing" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:4.0" status="urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success" requestId="c4369c4d-740e-4b64-80f0-7b209a66d629">
     <rim:Slot name="SpecificationIdentifier">
         <rim:SlotValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="rim:StringValueType">
             <rim:Value>toop-edm:v2.0</rim:Value>
@@ -36,7 +36,7 @@
         </rim:SlotValue>
     </rim:Slot>
     <rim:RegistryObjectList>
-        <rim:RegistryObject id="01ec5b03-df4e-44e1-bfcb-6b1c1b825bfd">
+        <rim:RegistryObject id="01ec5b03-df4e-44e1-bfcb-6b1c1b825bfd" xsi:type="rim:ExtrinsicObjectType">
             <rim:Slot name="DocumentMetadata">
                 <rim:SlotValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="rim:AnyValueType">
                     <dcat:Dataset xmlns:spdx="spdx:xsd::1.0" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:regorg="http://www.w3.org/ns/regorg#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:odrl="http://www.w3.org/ns/odrl/2/" xmlns:locn="http://www.w3.org/ns/locn#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:cccev="https://semic.org/sa/cv/cccev-2.0.0#" xmlns:cbc="https://semic.org/sa/cv/common/cbc-2.0.0#" xmlns:cagv="https://semic.org/sa/cv/cagv/agent-2.0.0#" xmlns:cac="https://semic.org/sa/cv/common/cac-2.0.0#" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:dcat="http://data.europa.eu/r5r/">
@@ -76,6 +76,9 @@
                     </dcat:Dataset>
                 </rim:SlotValue>
             </rim:Slot>
+            <!-- The attached Document Provided as Evidence. Points to an AS4 attachment -->
+            <rim:RepositoryItemRef xlink:href="cid:attachment123@example.toop.eu"
+                                   xlink:title="Company Registration Document"/>
         </rim:RegistryObject>
     </rim:RegistryObjectList>
 </query:QueryResponse>

--- a/toop-edm/src/test/resources/Document Response_NoRepositoryItemRef.xml
+++ b/toop-edm/src/test/resources/Document Response_NoRepositoryItemRef.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2018-2020 toop.eu
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<query:QueryResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:lcm="urn:oasis:names:tc:ebxml-regrep:xsd:lcm:4.0" xmlns:query="urn:oasis:names:tc:ebxml-regrep:xsd:query:4.0" xmlns:spi="urn:oasis:names:tc:ebxml-regrep:xsd:spi:4.0" xmlns:rs="urn:oasis:names:tc:ebxml-regrep:xsd:rs:4.0" xmlns:wsa="http://www.w3.org/2005/08/addressing" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:4.0" status="urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success" requestId="c4369c4d-740e-4b64-80f0-7b209a66d629">
+    <rim:Slot name="SpecificationIdentifier">
+        <rim:SlotValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="rim:StringValueType">
+            <rim:Value>toop-edm:v2.0</rim:Value>
+        </rim:SlotValue>
+    </rim:Slot>
+    <rim:Slot name="IssueDateTime">
+        <rim:SlotValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="rim:DateTimeValueType">
+            <rim:Value>2020-02-14T19:20:30.000</rim:Value>
+        </rim:SlotValue>
+    </rim:Slot>
+    <rim:Slot name="DataProvider">
+        <rim:SlotValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="rim:AnyValueType">
+            <cagv:Agent xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:regorg="http://www.w3.org/ns/regorg#" xmlns:locn="http://www.w3.org/ns/locn#" xmlns:cbc="https://semic.org/sa/cv/common/cbc-2.0.0#" xmlns:cac="https://semic.org/sa/cv/common/cac-2.0.0#" xmlns:cagv="https://semic.org/sa/cv/cagv/agent-2.0.0#">
+                <cbc:id schemeID="VAT">12345678</cbc:id>
+                <cbc:name>DPName</cbc:name>
+            </cagv:Agent>
+        </rim:SlotValue>
+    </rim:Slot>
+    <rim:RegistryObjectList>
+        <rim:RegistryObject id="01ec5b03-df4e-44e1-bfcb-6b1c1b825bfd" xsi:type="rim:ExtrinsicObjectType">
+            <rim:Slot name="DocumentMetadata">
+                <rim:SlotValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="rim:AnyValueType">
+                    <dcat:Dataset xmlns:spdx="spdx:xsd::1.0" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:regorg="http://www.w3.org/ns/regorg#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:odrl="http://www.w3.org/ns/odrl/2/" xmlns:locn="http://www.w3.org/ns/locn#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:cccev="https://semic.org/sa/cv/cccev-2.0.0#" xmlns:cbc="https://semic.org/sa/cv/common/cbc-2.0.0#" xmlns:cagv="https://semic.org/sa/cv/cagv/agent-2.0.0#" xmlns:cac="https://semic.org/sa/cv/common/cac-2.0.0#" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:dcat="http://data.europa.eu/r5r/">
+                        <dct:description>bla desc</dct:description>
+                        <dct:title>bla title</dct:title>
+                        <dcat:distribution xsi:type="cccev:DocumentReferenceType">
+                            <dcat:accessURL />
+                            <cccev:documentURI>URI</cccev:documentURI>
+                            <cccev:documentDescription>DocumentDescription</cccev:documentDescription>
+                            <cccev:documentType>docType</cccev:documentType>
+                            <cccev:localeCode>GR</cccev:localeCode>
+                        </dcat:distribution>
+                        <dct:creator xsi:type="cagv:AgentType">
+                            <cbc:name>Agent name</cbc:name>
+                            <cagv:location>
+                                <locn:address xsi:type="cac:AddressType">
+                                    <locn:postName>Kewlkidshome</locn:postName>
+                                </locn:address>
+                            </cagv:location>
+                        </dct:creator>
+                        <dct:identifier>RE238918378</dct:identifier>
+                        <dct:identifier>DOC-555</dct:identifier>
+                        <dct:issued>2020-05-10T14:10:14.562</dct:issued>
+                        <dct:language>en</dct:language>
+                        <dct:modified>2020-05-10T14:10:14.563</dct:modified>
+                        <dct:temporal>
+                            <dct:startDate>2020-04-10</dct:startDate>
+                            <dct:endDate>2021-05-10</dct:endDate>
+                        </dct:temporal>
+                        <dcat:qualifiedRelation>
+                            <dct:relation xsi:type="cccev:ReferenceFrameworkType">
+                                <dct:description>LegalResourceDesc</dct:description>
+                                <dct:title>Name</dct:title>
+                                <dct:identifier>RE238918378</dct:identifier>
+                            </dct:relation>
+                        </dcat:qualifiedRelation>
+                    </dcat:Dataset>
+                </rim:SlotValue>
+            </rim:Slot>
+        </rim:RegistryObject>
+    </rim:RegistryObjectList>
+</query:QueryResponse>


### PR DESCRIPTION
This PR will add:
- New ID slot for Second Step Document Request
- New QueryDefinition in EQueryDefinitionType for ObjectRef
- New builder methods for DocumentRef and GetDocumentByID in EDMRequest
- RepositoryItemRefPojo class
- repositoryItemRef in EDMResponse
- New builder method in EDMResponse for ObjectRef
and all related get/set/builder/creator/extractor methods. 